### PR TITLE
Fix hebrew support

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,67 +89,68 @@ $ git vus // git status
 ```
 
 # מצוות קדושות - holy mitzvis
+
 שלעפ טוישן
 ```
-$ git שלעפ // git pull
+$ gut שלעפ // git pull
 ```
 שטופ טוישן
 ```
-$ git שטופ // git push
+$ gut שטופ // git push
 ```
 חאפ טוישן
 ```
-$ git חאפ // git fetch
+$ gut חאפ // git fetch
 ```
 נפקא מינא
 ```
-$ git נפקא_מינא // git diff
+$ gut נפקא_מינא // git diff
 ```
 מאך טשאלנט
 ```
-$ git טשאלנט // git merge
+$ gut טשאלנט // git merge
 ```
 לשון הרע
 ```
-$ git לשון_הרע // git blame
+$ gut לשון_הרע // git blame
 ```
 וואַרפן צו די גניזה
 ```
-$ git גניזה // git stash
+$ gut גניזה // git stash
 ```
 גיט שמוץ ארויס
 ```
-$ git שמוץ // git stash
+$ gut שמוץ // git stash
 ```
 גיט פאַרבינדן
 ```
-$ git פאַרבינדן // git connect
+$ gut פאַרבינדן // git connect
 ```
 באַקומען די דרך
 ```
-$ git דרכים // git branch
+$ gut דרכים // git branch
 ```
 גיט אפיקורס
 ```
-$ git אפיקורס // git checkout -b
+$ gut אפיקורס // git checkout -b
 ```
 גיט נאך א מאל
 ```
-$ git נאך_א-מול // git rebase
+$ gut נאך_א-מול // git rebase
 ```
 גיט גוואַלד
 ```
-$ git גוואלד // git help
+$ gut גוואלד // git help
 ```
 גיט אוי ויי
 ```
-$ git אוי_ויי // git help
+$ gut אוי_ויי // git help
 ```
 גיט שמוז
 ```
-$ git שמוז // git log
+$ gut שמוז // git log
 ```
 גיט וואס
 ```
-$ git וואס // git status
+$ gut וואס // git status
 ```

--- a/README.md
+++ b/README.md
@@ -87,3 +87,69 @@ $ git shmooz // git log
 ```
 $ git vus // git status
 ```
+
+# מצוות קדושות - holy mitzvis
+שלעפ טוישן
+```
+$ git שלעפ // git pull
+```
+שטופ טוישן
+```
+$ git שטופ // git push
+```
+חאפ טוישן
+```
+$ git חאפ // git fetch
+```
+נפקא מינא
+```
+$ git נפקא_מינא // git diff
+```
+מאך טשאלנט
+```
+$ git טשאלנט // git merge
+```
+לשון הרע
+```
+$ git לשון_הרע // git blame
+```
+וואַרפן צו די גניזה
+```
+$ git גניזה // git stash
+```
+גיט שמוץ ארויס
+```
+$ git שמוץ // git stash
+```
+גיט פאַרבינדן
+```
+$ git פאַרבינדן // git connect
+```
+באַקומען די דרך
+```
+$ git דרכים // git branch
+```
+גיט אפיקורס
+```
+$ git אפיקורס // git checkout -b
+```
+גיט נאך א מאל
+```
+$ git נאך_א-מול // git rebase
+```
+גיט גוואַלד
+```
+$ git גוואלד // git help
+```
+גיט אוי ויי
+```
+$ git אוי_ויי // git help
+```
+גיט שמוז
+```
+$ git שמוז // git log
+```
+גיט וואס
+```
+$ git וואס // git status
+```

--- a/bin/gut.js
+++ b/bin/gut.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+const { spawn } = require('child_process');
+
+const hebrewCommands = {
+  'שלעפ': 'pull',
+  'שטופ': 'push',
+  'חאפ': 'fetch',
+  'נפקא_מינא': 'diff',
+  'טשאלנט': 'merge',
+  'לשון_הרע': 'blame',
+  'גניזה': 'stash',
+  'שמוץ': 'stash',
+  'פאַרבינדן': 'connect',
+  'דרכים': 'branch',
+  'אפיקורס': ['checkout', '-b'],
+  'נאך_א-מול': 'rebase',
+  'גוואלד': 'help',
+  'אוי_ויי': 'help',
+  'שמוז': 'log',
+  'וואס': 'status',
+};
+
+const args = process.argv.slice(2);
+
+if (args.length === 0) {
+  console.log('Usage: gut <command> [options]');
+  console.log('\nHebrew commands:');
+  Object.entries(hebrewCommands).forEach(([hebrew, english]) => {
+    const cmd = Array.isArray(english) ? english.join(' ') : english;
+    console.log(`  ${hebrew} => git ${cmd}`);
+  });
+  process.exit(0);
+}
+
+// Translate first argument if it's Hebrew
+let gitArgs = [...args];
+const firstArg = args[0];
+
+if (hebrewCommands[firstArg]) {
+  const translated = hebrewCommands[firstArg];
+  if (Array.isArray(translated)) {
+    gitArgs = [...translated, ...args.slice(1)];
+  } else {
+    gitArgs = [translated, ...args.slice(1)];
+  }
+  console.log(`🕎 ${firstArg} => git ${gitArgs.join(' ')}`);
+}
+
+// Run git with translated arguments
+const git = spawn('git', gitArgs, { stdio: 'inherit' });
+
+git.on('close', (code) => {
+  process.exit(code);
+});

--- a/bin/gut.js
+++ b/bin/gut.js
@@ -44,7 +44,7 @@ if (hebrewCommands[firstArg]) {
   } else {
     gitArgs = [translated, ...args.slice(1)];
   }
-  console.log(`🕎 ${firstArg} => git ${gitArgs.join(' ')}`);
+  console.log(`${firstArg} => git ${gitArgs.join(' ')}`);
 }
 
 // Run git with translated arguments

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,24 @@ var configure = function() {
     'alias.givald': 'help',
     'alias.oy-vey': 'help',
     'alias.shmooz': 'log',
-    'alias.nochamol': 'rebase'
+    'alias.nochamol': 'rebase',
+
+    'alias.שלעפ': 'pull',
+    'alias.שטופ': 'push',
+    'alias.חאפ': 'fetch',
+    'alias.נפקא_מינא': 'diff',
+    'alias.טשאלנט': 'merge',
+    'alias.לשון_הרע': 'blame',
+    'alias.גניזה': 'stash',
+    'alias.שמוץ': 'stash',
+    'alias.פאַרבינדן': 'connect',
+    'alias.דרכים': 'branch',
+    'alias.אפיקורס': 'checkout -b',
+    'alias.נאך_א-מול': 'rebase',
+    'alias.גוואלד': 'help',
+    'alias.אוי_ויי': 'help',
+    'alias.שמוז': 'log',
+    'alias.וואס': 'status',
   }, { location: 'global' }).then();
 
   setTimeout(function() {

--- a/lib/uninstall.js
+++ b/lib/uninstall.js
@@ -2,12 +2,19 @@ const gitconfig = require('gitconfig');
 
 var uninstall = function() {
   console.log("Trefing up Git...");
-  gitconfig.unset(['alias.vus', 'alias.chollent', 'alias.shlep',
+  gitconfig.unset([
+    // English/Yiddish aliases
+    'alias.vus', 'alias.chollent', 'alias.shlep',
     'alias.chap', 'alias.shtup', 'alias.loshon-hora',
     'alias.nafka-mina', 'alias.gniza', 'alias.farbinden',
     'alias.apikoyres', 'alias.drochim', 'alias.givald', 'alias.oy-vey',
-    'alias.shmutz', 'alias.shmooz', 'alias.nochamol'],
-    { location: 'global' }).then();
+    'alias.shmutz', 'alias.shmooz', 'alias.nochamol',
+    // Hebrew aliases
+    'alias.שלעפ', 'alias.שטופ', 'alias.חאפ', 'alias.נפקא_מינא',
+    'alias.טשאלנט', 'alias.לשון_הרע', 'alias.גניזה', 'alias.שמוץ',
+    'alias.פאַרבינדן', 'alias.דרכים', 'alias.אפיקורס', 'alias.נאך_א-מול',
+    'alias.גוואלד', 'alias.אוי_ויי', 'alias.שמוז', 'alias.וואס'
+  ], { location: 'global' }).then();
 
   setTimeout(function() {
     console.log("nebuch, Git is now treif.");

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "bin": {
       "kasher-git": "./bin/git-shabis-setup.js",
-      "treif-up-git": "./bin/git-shabis-destroy.js" 
+      "treif-up-git": "./bin/git-shabis-destroy.js",
+      "gut": "./bin/gut.js"
   },
   "preferGlobal": true
 }


### PR DESCRIPTION


according to the issue brought up by @Theacebutler Hebrew alias were not working. Looking into it, I discovered two problems:

Issue 1: The uninstall.js was missing all Hebrew aliases - so even if they worked, treif-up-git wouldn't clean them up.

Issue 2 (the real problem): Git itself doesn't support non-ASCII characters in alias names. Running git config --global alias.וואס status returns error: invalid key. This means the Hebrew aliases in index.js were silently failing and never actually being set.

Solution: Since git has this fundamental limitation, I created a new wrapper command called gut (גוט) that:

Accepts Hebrew commands as arguments
Translates them to their git equivalents
Passes them through to git
Now users can run:

gut וואס     → git status
gut שלעפ     → git pull
gut שטופ     → git push

Changes:

Added gut.js - Hebrew command translator
Updated package.json to include gut binary
Updated uninstall.js to remove Hebrew aliases (cleanup for anyone who had old broken config)
Updated README with gut documentation
